### PR TITLE
Config: remove volume to binds mount

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -218,11 +218,6 @@ func (s Service) CreateContainerOptions() (docker.CreateContainerOptions, error)
 
 	if len(s.Volumes) > 0 {
 		for _, vol := range s.Volumes {
-			bind := vol.Source + ":" + vol.Target
-			if vol.ReadOnly {
-				bind += ":" + "ro"
-			}
-			c.HostConfig.Binds = append(c.HostConfig.Binds, bind)
 			hm := docker.HostMount{
 				Source:   vol.Source,
 				Target:   vol.Target,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -157,7 +157,6 @@ func TestLoader(t *testing.T) {
 						AttachStdout: true,
 					},
 					HostConfig: &docker.HostConfig{
-						Binds: []string{"certs:/certs"},
 						PortBindings: map[docker.Port][]docker.PortBinding{
 							docker.Port("443/tcp"): {{
 								HostPort: "443",


### PR DESCRIPTION
The compose Volume could map to either Binds or Volume, so it used to map to both, but it may have resulted in the "API error (400): Duplicate mount point: /certs" error seen.